### PR TITLE
Adds 400 response for invalid files provided via the url param

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,11 @@ async fn index(
                 error_str,
                 vips_data.error_buffer().unwrap_or("").replace("\n", ". ")
             );
-            Err(actix_web::error::ErrorInternalServerError(e))
+            let error_response = match e {
+                actix_web::error::BlockingError::Error(libvips::error::Error::InitializationError(_)) => actix_web::error::ErrorBadRequest(e),
+                _ => actix_web::error::ErrorInternalServerError(e)
+            };
+            Err(error_response)
         }
         Ok(res_body) => {
             match format {


### PR DESCRIPTION
I added some minor error handling in order to return 400 Bad Request in case of an invalid file (not image) provided by the url parameter.

In this situation InitializationError is thrown by libvips and is available in the BlockingError.