### PR TITLE
Fix for tests in pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "dali"
-version = "1.0.8"
+version = "1.0.10"
 dependencies = [
  "actix-http",
  "actix-rt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "dali"
-version = "1.0.10"
+version = "1.0.9"
 dependencies = [
  "actix-http",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # (c) Copyright 2019-2020 OLX
 [package]
 name = "dali"
-version = "1.0.10"
+version = "1.0.9"
 authors = ["Augusto César Dias <augusto.dias@olx.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # (c) Copyright 2019-2020 OLX
 [package]
 name = "dali"
-version = "1.0.8"
+version = "1.0.10"
 authors = ["Augusto César Dias <augusto.dias@olx.com>"]
 edition = "2018"
 

--- a/docker-compose.tests.yaml
+++ b/docker-compose.tests.yaml
@@ -9,4 +9,15 @@ services:
     volumes:
         - ./:/src
     working_dir: /src
-    command: cargo test
+    # In the starting commands we remove trust-ad from /etc/resolv.conf because the transitive dependency
+    # trust-dns-resolver (v0.18.0-alpha.2) that handles dns queries for actix-http inside actix-connect
+    # doesn't support that marker. Currently, this issue has been fixed in trust-dns-resolver (v0.20.0),
+    # but no actix-http stable release uses it. Since this issue is happening only during the GitHub pipeline
+    # we can remove trust-ad from /etc/resolv.conf inside this docker-compose. After a stable release of actix-http,
+    # that has at least v0.20.0 of trust-dns-resolver is released, we can upgrade.
+    command: >
+            sh -c "tmp_resolv_conf=\"$$(mktemp)\" &&
+                sed '/^options /s/\<trust-ad\>//g' /etc/resolv.conf >\"$$tmp_resolv_conf\" &&
+                cat \"$$tmp_resolv_conf\" > /etc/resolv.conf &&
+                rm -f \"$$tmp_resolv_conf\" &&
+                cargo test"


### PR DESCRIPTION
With the newer docker versions /etc/resolv.conf contains some new values (trust-ad). In the [docker-compose.test.yaml](https://github.com/olxgroup-oss/dali/compare/master...BogdanVidrean:Fixing_testing_docker_dns_problem_with_actix_during_pipeline?expand=1#diff-ab882918397291466b74d975701649a968a25a53011c133426c7d6c08fd903a7) starting command was updated to remove trust-ad from /etc/resolv.conf because the transitive dependency
trust-dns-resolver (v0.18.0-alpha.2) that handles dns queries for actix-http inside actix-connect
doesn't support that marker. Currently, this issue has been fixed in trust-dns-resolver (v0.20.0),
but no actix-http stable release uses it. Since this issue is happening only during the GitHub pipeline
we can remove trust-ad from /etc/resolv.conf inside this docker-compose. After a stable release of actix-http,
that has at least v0.20.0 of trust-dns-resolver is released, we can upgrade.

The entire issue is very nicely described [here](https://forum.sentry.io/t/relay-errors-in-fresh-new-on-premise-install/9804/26).