### PR TITLE
feat(perf): manually install and configure libvips

### DIFF
--- a/.github/workflows/pull-requests-tests.yml
+++ b/.github/workflows/pull-requests-tests.yml
@@ -30,7 +30,6 @@ jobs:
           vips-dev=8.13.3-r1
           vips-heif=8.13.3-r1
           tar
-          openssl
       - name: Check if nginx is available for files hosting
         run:  curl http://backend/exif --output /dev/null
       - uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "dali"
-version = "1.6.0"
+version = "1.5.0"
 dependencies = [
  "actix-http",
  "actix-rt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,202 +4,297 @@ version = 3
 
 [[package]]
 name = "actix-codec"
-version = "0.5.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617a8268e3537fe1d8c9ead925fca49ef6400927ee7bc26750e90ecee14ce4b8"
+checksum = "09e55f0a5c2ca15795035d90c46bd0e73a5123b72f68f12596d6ba5282051380"
 dependencies = [
  "bitflags 1.3.2",
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
- "memchr",
- "pin-project-lite",
+ "log",
  "tokio",
- "tokio-util",
- "tracing",
+ "tokio-util 0.2.0",
+]
+
+[[package]]
+name = "actix-codec"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78d1833b3838dbe990df0f1f87baf640cf6146e898166afe401839d1b001e570"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytes 0.5.6",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project 0.4.28",
+ "tokio",
+ "tokio-util 0.3.1",
+]
+
+[[package]]
+name = "actix-connect"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c95cc9569221e9802bf4c377f6c18b90ef10227d787611decf79fd47d2a8e76c"
+dependencies = [
+ "actix-codec 0.2.0",
+ "actix-rt",
+ "actix-service",
+ "actix-utils 1.0.6",
+ "derive_more",
+ "either",
+ "futures",
+ "http",
+ "log",
+ "trust-dns-proto",
+ "trust-dns-resolver",
 ]
 
 [[package]]
 name = "actix-http"
-version = "3.4.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92ef85799cba03f76e4f7c10f533e66d87c9a7e7055f3391f09000ad8351bc9"
+checksum = "c16664cc4fdea8030837ad5a845eb231fb93fc3c5c171edfefb52fad92ce9019"
 dependencies = [
- "actix-codec",
+ "actix-codec 0.2.0",
+ "actix-connect",
  "actix-rt",
  "actix-service",
- "actix-utils",
- "ahash 0.8.6",
- "base64 0.21.5",
- "bitflags 2.4.1",
- "brotli",
- "bytes",
- "bytestring",
+ "actix-threadpool",
+ "actix-utils 1.0.6",
+ "base64 0.11.0",
+ "bitflags 1.3.2",
+ "brotli2",
+ "bytes 0.5.6",
+ "chrono",
+ "copyless",
  "derive_more",
+ "either",
  "encoding_rs",
+ "failure",
  "flate2",
+ "futures-channel",
  "futures-core",
+ "futures-util",
+ "fxhash",
  "h2",
  "http",
  "httparse",
- "httpdate",
- "itoa",
+ "indexmap",
  "language-tags",
- "local-channel",
+ "lazy_static",
+ "log",
  "mime",
  "percent-encoding",
- "pin-project-lite",
+ "pin-project 0.4.28",
  "rand",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
  "sha1",
- "smallvec",
- "tokio",
- "tokio-util",
- "tracing",
- "zstd",
+ "slab",
+ "time",
 ]
 
 [[package]]
 name = "actix-macros"
-version = "0.2.4"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
+checksum = "b4ca8ce00b267af8ccebbd647de0d61e0674b6e61185cc7a592ff88772bed655"
 dependencies = [
  "quote",
- "syn 2.0.38",
+ "syn 1.0.76",
 ]
 
 [[package]]
 name = "actix-router"
-version = "0.5.1"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66ff4d247d2b160861fa2866457e85706833527840e4133f8f49aa423a38799"
+checksum = "2ad299af73649e1fc893e333ccf86f377751eb95ff875d095131574c6f43452c"
 dependencies = [
  "bytestring",
  "http",
+ "log",
  "regex",
  "serde",
- "tracing",
 ]
 
 [[package]]
 name = "actix-rt"
-version = "2.9.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f32d40287d3f402ae0028a9d54bef51af15c8769492826a69d28f81893151d"
+checksum = "143fcc2912e0d1de2bcf4e2f720d2a60c28652ab4179685a1ee159e0fb3db227"
 dependencies = [
  "actix-macros",
- "futures-core",
+ "actix-threadpool",
+ "copyless",
+ "futures-channel",
+ "futures-util",
+ "smallvec",
  "tokio",
 ]
 
 [[package]]
 name = "actix-server"
-version = "2.3.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb13e7eef0423ea6eab0e59f6c72e7cb46d33691ad56a726b3cd07ddec2c2d4"
+checksum = "45407e6e672ca24784baa667c5d32ef109ccdd8d5e0b5ebb9ef8a67f4dfb708e"
 dependencies = [
+ "actix-codec 0.3.0",
  "actix-rt",
  "actix-service",
- "actix-utils",
- "futures-core",
+ "actix-utils 2.0.0",
+ "futures-channel",
  "futures-util",
+ "log",
  "mio",
- "socket2 0.5.5",
- "tokio",
- "tracing",
+ "mio-uds",
+ "num_cpus",
+ "slab",
+ "socket2",
 ]
 
 [[package]]
 name = "actix-service"
-version = "2.0.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
+checksum = "0052435d581b5be835d11f4eb3bce417c8af18d87ddf8ace99f8e67e595882bb"
 dependencies = [
- "futures-core",
- "paste",
- "pin-project-lite",
+ "futures-util",
+ "pin-project 0.4.28",
+]
+
+[[package]]
+name = "actix-testing"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47239ca38799ab74ee6a8a94d1ce857014b2ac36f242f70f3f75a66f691e791c"
+dependencies = [
+ "actix-macros",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "log",
+ "socket2",
+]
+
+[[package]]
+name = "actix-threadpool"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d209f04d002854b9afd3743032a27b066158817965bf5d036824d19ac2cc0e30"
+dependencies = [
+ "derive_more",
+ "futures-channel",
+ "lazy_static",
+ "log",
+ "num_cpus",
+ "parking_lot 0.11.2",
+ "threadpool",
 ]
 
 [[package]]
 name = "actix-tls"
-version = "3.1.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72616e7fbec0aa99c6f3164677fa48ff5a60036d0799c98cab894a44f3e0efc3"
+checksum = "a4e5b4faaf105e9a6d389c606c298dcdb033061b00d532af9df56ff3a54995a8"
 dependencies = [
+ "actix-codec 0.2.0",
  "actix-rt",
  "actix-service",
- "actix-utils",
- "futures-core",
- "http",
- "impl-more",
- "pin-project-lite",
- "rustls",
- "rustls-webpki",
- "tokio",
- "tokio-util",
- "tracing",
+ "actix-utils 1.0.6",
+ "derive_more",
+ "either",
+ "futures",
+ "log",
 ]
 
 [[package]]
 name = "actix-utils"
-version = "3.0.1"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+checksum = "fcf8f5631bf01adec2267808f00e228b761c60c0584cc9fa0b5364f41d147f4e"
 dependencies = [
- "local-waker",
- "pin-project-lite",
+ "actix-codec 0.2.0",
+ "actix-rt",
+ "actix-service",
+ "bitflags 1.3.2",
+ "bytes 0.5.6",
+ "either",
+ "futures",
+ "log",
+ "pin-project 0.4.28",
+ "slab",
+]
+
+[[package]]
+name = "actix-utils"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9022dec56632d1d7979e59af14f0597a28a830a9c1c7fec8b2327eb9f16b5a"
+dependencies = [
+ "actix-codec 0.3.0",
+ "actix-rt",
+ "actix-service",
+ "bitflags 1.3.2",
+ "bytes 0.5.6",
+ "either",
+ "futures-channel",
+ "futures-sink",
+ "futures-util",
+ "log",
+ "pin-project 0.4.28",
+ "slab",
 ]
 
 [[package]]
 name = "actix-web"
-version = "4.4.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4a5b5e29603ca8c94a77c65cf874718ceb60292c5a5c3e5f4ace041af462b9"
+checksum = "3158e822461040822f0dbf1735b9c2ce1f95f93b651d7a7aded00b1efbb1f635"
 dependencies = [
- "actix-codec",
+ "actix-codec 0.2.0",
  "actix-http",
  "actix-macros",
  "actix-router",
  "actix-rt",
  "actix-server",
  "actix-service",
- "actix-utils",
+ "actix-testing",
+ "actix-threadpool",
+ "actix-tls",
+ "actix-utils 1.0.6",
  "actix-web-codegen",
- "ahash 0.8.6",
- "bytes",
- "bytestring",
- "cfg-if",
- "cookie",
+ "awc",
+ "bytes 0.5.6",
  "derive_more",
  "encoding_rs",
- "futures-core",
- "futures-util",
- "itoa",
- "language-tags",
+ "futures",
+ "fxhash",
  "log",
  "mime",
- "once_cell",
- "pin-project-lite",
+ "net2",
+ "pin-project 0.4.28",
  "regex",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "smallvec",
- "socket2 0.5.5",
  "time",
  "url",
 ]
 
 [[package]]
 name = "actix-web-codegen"
-version = "4.2.2"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1f50ebbb30eca122b188319a4398b3f7bb4a8cdf50ecfb73bfc6a3c3ce54f5"
+checksum = "a71bf475cbe07281d0b3696abb48212db118e7e23219f13596ce865235ff5766"
 dependencies = [
- "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 1.0.76",
 ]
 
 [[package]]
@@ -223,22 +318,9 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "once_cell",
  "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
-dependencies = [
- "cfg-if",
- "getrandom",
- "once_cell",
- "version_check",
- "zerocopy",
 ]
 
 [[package]]
@@ -248,21 +330,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -284,35 +351,25 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "awc"
-version = "3.2.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa3c705a9c7917ac0f41c0757a0a747b43bbc29b0b364b081bd7c5fc67fb223"
+checksum = "d7601d4d1d7ef2335d6597a41b5fe069f6ab799b85f53565ab390e7b7065aac5"
 dependencies = [
- "actix-codec",
+ "actix-codec 0.2.0",
  "actix-http",
  "actix-rt",
  "actix-service",
- "actix-tls",
- "actix-utils",
- "base64 0.21.5",
- "bytes",
- "cfg-if",
- "cookie",
+ "base64 0.11.0",
+ "bytes 0.5.6",
  "derive_more",
  "futures-core",
- "futures-util",
- "h2",
- "http",
- "itoa",
  "log",
  "mime",
  "percent-encoding",
- "pin-project-lite",
  "rand",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
 ]
 
 [[package]]
@@ -323,7 +380,7 @@ checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -332,15 +389,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
@@ -364,24 +421,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "3.4.0"
+name = "brotli-sys"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
+checksum = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
 dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
+ "cc",
+ "libc",
 ]
 
 [[package]]
-name = "brotli-decompressor"
-version = "2.5.1"
+name = "brotli2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+checksum = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
 dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
+ "brotli-sys",
+ "libc",
 ]
 
 [[package]]
@@ -389,6 +445,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
@@ -402,24 +464,39 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90706ba19e97b90786e19dc0d5e2abd80008d99d4c0c5d1ad0b5e72cec7c494d"
 dependencies = [
- "bytes",
+ "bytes 1.1.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "jobserver",
- "libc",
-]
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "config"
@@ -447,15 +524,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
-name = "cookie"
-version = "0.16.0"
+name = "copyless"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
+checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
 
 [[package]]
 name = "cpufeatures"
@@ -472,7 +544,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -493,8 +565,6 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-web",
- "awc",
- "cfg-if",
  "config",
  "env_logger",
  "futures",
@@ -504,7 +574,6 @@ dependencies = [
  "libvips",
  "log",
  "num_cpus",
- "pkg-config",
  "prometheus",
  "prometheus-static-metric",
  "rexif",
@@ -515,13 +584,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.9"
+name = "data-encoding"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
-dependencies = [
- "powerfmt",
-]
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "derive_more"
@@ -553,12 +619,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.76",
 ]
 
 [[package]]
@@ -585,12 +675,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.76",
+ "synstructure",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -611,6 +723,22 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags 1.3.2",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
@@ -696,9 +824,18 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -713,13 +850,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -730,11 +878,11 @@ checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "h2"
-version = "0.3.21"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -743,8 +891,9 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.3.1",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -759,7 +908,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.7",
+ "ahash",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -775,38 +933,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "http"
-version = "0.2.9"
+name = "hostname"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
- "bytes",
+ "libc",
+ "match_cfg",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "http"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+dependencies = [
+ "bytes 1.1.0",
  "fnv",
- "itoa",
+ "itoa 0.4.8",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "http",
- "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
-version = "1.0.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
@@ -816,11 +984,11 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -829,9 +997,9 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.4.10",
+ "itoa 0.4.8",
+ "pin-project 1.0.8",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -840,12 +1008,12 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+checksum = "0d1f9b0b8258e3ef8f45928021d3ef14096c2b93b99e4b8cfcabf1f58ec84b0a"
 dependencies = [
+ "bytes 0.5.6",
  "hyper",
- "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
 ]
@@ -862,12 +1030,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-more"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206ca75c9c03ba3d4ace2460e57b189f39f43de612c2f85836e65c929701bb2d"
-
-[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +1037,15 @@ checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -886,6 +1057,27 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
+dependencies = [
+ "socket2",
+ "widestring",
+ "winapi 0.3.9",
+ "winreg",
 ]
 
 [[package]]
@@ -901,18 +1093,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
-
-[[package]]
-name = "jobserver"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "json5"
@@ -926,10 +1115,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "language-tags"
-version = "0.3.2"
+name = "kernel32-sys"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
+name = "language-tags"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
@@ -972,23 +1171,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
-name = "local-channel"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
-dependencies = [
- "futures-core",
- "futures-sink",
- "local-waker",
-]
-
-[[package]]
-name = "local-waker"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
-
-[[package]]
 name = "lock_api"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1184,21 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matches"
@@ -1039,14 +1236,55 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
+ "cfg-if 0.1.10",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
  "libc",
  "log",
- "wasi",
- "windows-sys 0.48.0",
+ "miow",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio-uds"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
+dependencies = [
+ "iovec",
+ "libc",
+ "mio",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1183,12 +1421,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.10",
+ "smallvec",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1197,18 +1460,12 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pathdiff"
@@ -1268,28 +1525,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.13"
+name = "pin-project"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
+dependencies = [
+ "pin-project-internal 0.4.28",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+dependencies = [
+ "pin-project-internal 1.0.8",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.76",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.76",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1325,12 +1616,12 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
  "libc",
  "memchr",
- "parking_lot",
+ "parking_lot 0.12.1",
  "procfs",
  "protobuf",
  "thiserror",
@@ -1355,6 +1646,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23129d50f2c9355ced935fce8a08bd706ee2e7ce2b3b33bf61dace0e379ac63a"
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,20 +1662,22 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha",
  "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1386,11 +1685,29 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1420,26 +1737,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
+name = "resolv-conf"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11834e137f3b14e309437a8276714eed3a80d1ef894869e510f2c0c0b98b9f4a"
+dependencies = [
+ "hostname",
+ "quick-error",
+]
+
+[[package]]
 name = "rexif"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49352965b70522af9085d7a8c2a6df7494713c67ac58b9af02bcff7fb4ca1483"
 dependencies = [
  "num",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
-dependencies = [
- "cc",
- "getrandom",
- "libc",
- "spin",
- "untrusted",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1459,7 +1772,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "ordered-multimap",
 ]
 
@@ -1506,28 +1819,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.21.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki",
- "sct",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,16 +1829,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "semver"
@@ -1593,18 +1874,19 @@ version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
- "itoa",
+ "itoa 1.0.9",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_qs"
-version = "0.12.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0431a35568651e363364210c91983c1da5eb29404d9f0928b67d4ebcfa7d330c"
+checksum = "5af82de3c6549b001bec34961ff2d6a54339a87bab37ce901b693401f27de6cb"
 dependencies = [
  "actix-web",
+ "data-encoding",
  "futures",
  "percent-encoding",
  "serde",
@@ -1613,26 +1895,21 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
+ "dtoa",
+ "itoa 0.4.8",
  "serde",
+ "url",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
@@ -1640,7 +1917,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
 ]
@@ -1668,29 +1945,14 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
+ "cfg-if 1.0.0",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
-
-[[package]]
-name = "socket2"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "syn"
@@ -1712,6 +1974,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.76",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1744,32 +2018,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.30"
+name = "threadpool"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
- "deranged",
- "itoa",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
+ "num_cpus",
 ]
 
 [[package]]
-name = "time-core"
-version = "0.1.2"
+name = "time"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
- "time-core",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1789,43 +2054,61 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
 dependencies = [
- "backtrace",
- "bytes",
+ "bytes 0.5.6",
+ "fnv",
+ "futures-core",
+ "iovec",
+ "lazy_static",
  "libc",
+ "memchr",
  "mio",
- "parking_lot",
- "pin-project-lite",
+ "mio-uds",
+ "pin-project-lite 0.1.12",
  "signal-hook-registry",
- "socket2 0.5.5",
- "windows-sys 0.48.0",
+ "slab",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "tokio-io-timeout"
-version = "1.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+checksum = "9390a43272c8a6ac912ed1d1e2b6abeafd5047e05530a2fa304deee041a06215"
 dependencies = [
- "pin-project-lite",
+ "bytes 0.5.6",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
- "pin-project-lite",
+ "log",
+ "pin-project-lite 0.1.12",
  "tokio",
- "tracing",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite 0.1.12",
+ "tokio",
 ]
 
 [[package]]
@@ -1845,22 +2128,72 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
+ "cfg-if 1.0.0",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.7",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "46125608c26121c81b0c6d693eab5a420e416da7e43c426d2e8f7df8da8a3acf"
 dependencies = [
- "once_cell",
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project 1.0.8",
+ "tracing",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.18.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a7f3a2ab8a919f5eca52a468866a67ed7d3efa265d48a652a9a3452272b413f"
+dependencies = [
+ "async-trait",
+ "enum-as-inner",
+ "failure",
+ "futures",
+ "idna",
+ "lazy_static",
+ "log",
+ "rand",
+ "smallvec",
+ "socket2",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.18.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f90b1502b226f8b2514c6d5b37bafa8c200d7ca4102d57dc36ee0f3b7a04a2f"
+dependencies = [
+ "cfg-if 0.1.10",
+ "failure",
+ "futures",
+ "ipconfig",
+ "lazy_static",
+ "log",
+ "lru-cache",
+ "resolv-conf",
+ "smallvec",
+ "tokio",
+ "trust-dns-proto",
 ]
 
 [[package]]
@@ -1903,16 +2236,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1928,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "want"
@@ -1944,9 +2277,33 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "widestring"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
@@ -1957,6 +2314,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1970,7 +2333,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2112,59 +2475,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
+name = "winreg"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd369a67c0edfef15010f980c3cbe45d7f651deac2cd67ce097cd801de16557"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f140bda219a26ccc0cdb03dba58af72590c53b22642577d88a927bc5c87d6b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
-]
-
-[[package]]
-name = "zstd"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "6.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "dali"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "actix-http",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # (c) Copyright 2019-2023 OLX
 [package]
 name = "dali"
-version = "1.5.0"
+version = "1.6.0"
 authors = ["Augusto César Dias <augusto.dias@olx.com>"]
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,39 +3,31 @@
 name = "dali"
 version = "1.5.0"
 authors = ["Augusto César Dias <augusto.dias@olx.com>"]
-edition = "2021"
+edition = "2018"
 
 [features]
 default = ["hyper_client"]
 hyper_client = ["hyper", "hyper-timeout"]
-awc_client = ["awc"]
-
-[build-dependencies]
-pkg-config = "0.3.27"
-
-[dev-dependencies]
-awc = { version = "3.2.0", features = [] }
+awc = []
 
 [dependencies]
 futures = "0.3.29"
-actix-web = "4.4.0"
-actix-rt = "2.9.0"
-actix-service = "2.0.2"
-actix-http = "3.4.0"
+actix-web = "2.0.0"
+actix-rt = "1.1.1"
+actix-service = "1.0.6"
+actix-http = "1.0.1"
 num_cpus = "1.16.0"
 prometheus = {version = "0.13.3", features = ["process", "nightly"] }
 prometheus-static-metric = "0.5.1"
 log = "0.4.20"
-env_logger = "0.10.1"
-serde = "1.0.192"
-serde_derive = "1.0.192"
+env_logger = "0.10.0"
+serde = "1.0.190"
+serde_derive = "1.0.190"
 serde_json = "1.0.108"
-serde_qs = {version = "0.12.0", features=["actix4"]}
+serde_qs = {version = "0.7.0", features=["actix"]}
 config = "0.13.3"
-hyper = { version = "0.14.27", features=["full"], optional = true }
-hyper-timeout = { version = "0.4.1", optional = true }
+hyper = { version = "0.13.7", optional = true }
+hyper-timeout = { version = "0.3.1", optional = true }
 libvips = "1.5.0"
 rexif = "0.7.3"
 lazy_static = "1.4.0"
-cfg-if = "1.0.0"
-awc = {version = "3.2.0", features=[], optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # (c) Copyright 2019-2023 OLX
 [package]
 name = "dali"
-version = "1.6.0"
+version = "1.5.0"
 authors = ["Augusto César Dias <augusto.dias@olx.com>"]
 edition = "2021"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,32 +38,37 @@ COPY . .
 RUN RUSTFLAGS="-C target-feature=-crt-static $(pkg-config vips --libs)" cargo build --release
 
 FROM alpine:3.18.4
+ENV GI_TYPELIB_PATH=/usr/lib/girepository-1.0
 
+# With the next command, the libvips bianries are copied from the previous stage hence we don't have to install it again.
+# The default location where the `configure` script installs libvips is `/usr/local/lib` unless overridden by `--prefix`
+# which we don't do.
+# !!! Also it's essential for the next `COPY` command to be executed before adding the rest of the packages thus the
+# libvips binaries are included in the ldconfig cache.
 COPY --from=build /usr/local/lib /usr/local/lib
 
 RUN apk add --update --no-cache  \
     --repository=https://dl-cdn.alpinelinux.org/alpine/v3.18/main  \
     --repository=https://dl-cdn.alpinelinux.org/alpine/v3.18/community \
-      libgsf=1.14.50-r1 \
-      glib=2.76.4-r0 \
       expat=2.5.0-r1 \
-      tiff=4.5.1-r0 \
-      libjpeg-turbo=2.1.5.1-r3 \
-      libexif=0.6.24-r1 \
       giflib=5.2.1-r4 \
-      librsvg=2.56.3-r0 \
+      glib=2.76.4-r0 \
       lcms2=2.15-r2 \
-      libpng=1.6.39-r3 \
-      orc=0.4.34-r0 \
-      libwebp=1.3.2-r0 \
-      libimagequant=4.2.0-r0 \
+      libde265=1.0.12-r0 \
+      libexif=0.6.24-r1 \
+      libgsf=1.14.50-r1 \
       libheif=1.16.2-r0 \
-      libde265=1.0.12-r0
-
-ENV GI_TYPELIB_PATH=/usr/lib/girepository-1.0
+      libimagequant=4.2.0-r0 \
+      libjpeg-turbo=2.1.5.1-r3 \
+      libpng=1.6.39-r3 \
+      librsvg=2.56.3-r0 \
+      libwebp=1.3.2-r0 \
+      openssl=3.1.4-r2 \
+      orc=0.4.34-r0 \
+      tiff=4.5.1-r0
 
 COPY --from=build /usr/src/dali/target/release/dali /usr/local/bin/dali
 
+# Running as root is dangerous as it can lead to several unexpected side effects
 USER nobody
-
 CMD ["dali"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,9 @@ RUN wget https://github.com/libvips/libvips/releases/download/v8.13.3/vips-8.13.
     mkdir /vips && \
     tar xvzf vips-8.13.3.tar.gz -C /vips --strip-components 1 && \
     cd /vips && \
-    ./configure --enable-debug=no && \
+    ./configure --enable-debug=no --without-OpenEXR --disable-static --enable-silent-rule && \
     make && \
     make install && \
-    ldconfig /etc/ld.so.conf.d && \
     rm -rf vips vips-8.13.3.tar.gz
 
 COPY . .
@@ -40,34 +39,7 @@ RUN RUSTFLAGS="-C target-feature=-crt-static $(pkg-config vips --libs)" cargo bu
 
 FROM alpine:3.18.4
 
-RUN apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/main --virtual build-deps \
-      build-base=0.5-r3 \
-      clang=16.0.6-r1 \
-      clang16-libclang=16.0.6-r1 \
-      expat-dev=2.5.0-r1 \
-      giflib-dev=5.2.1-r4 \
-      glib-dev=2.76.4-r0 \
-      lcms2-dev=2.15-r2 \
-      libexif-dev=0.6.24-r1 \
-      libheif-dev=1.16.2-r0 \
-      libimagequant-dev=4.2.0-r0 \
-      libjpeg-turbo-dev=2.1.5.1-r3 \
-      libpng-dev=1.6.39-r3 \
-      librsvg-dev=2.56.3-r0 \
-      libwebp-dev=1.3.2-r0 \
-      openssl-dev=3.1.4-r1 \
-      orc-dev=0.4.34-r0 \
-      pkgconf=1.9.5-r0 \
-      tiff-dev=4.5.1-r0 && \
-    wget https://github.com/libvips/libvips/releases/download/v8.13.3/vips-8.13.3.tar.gz && \
-    mkdir /vips &&\
-    tar xvzf vips-8.13.3.tar.gz -C /vips --strip-components 1 && \
-    cd /vips && \
-    ./configure --enable-debug=no --without-OpenEXR --disable-static --enable-silent-rule && \
-    make install-strip  && \
-    ldconfig /etc/ld.so.conf.d && \
-    rm -rf /vips /vips-8.13.3.tar.gz && \
-    apk del build-deps
+COPY --from=build /usr/local/lib /usr/local/lib
 
 RUN apk add --update --no-cache  \
     --repository=https://dl-cdn.alpinelinux.org/alpine/v3.18/main  \
@@ -88,8 +60,10 @@ RUN apk add --update --no-cache  \
       libheif=1.16.2-r0 \
       libde265=1.0.12-r0
 
-ENV GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0
+ENV GI_TYPELIB_PATH=/usr/lib/girepository-1.0
 
 COPY --from=build /usr/src/dali/target/release/dali /usr/local/bin/dali
+
+USER nobody
 
 CMD ["dali"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,28 @@
 # (c) Copyright 2019-2023 OLX
+# We are manually installing and configuring libvips and each required package because previously when trying to use
+# the community built bundles (i.e. vips and vips-heif) the performace of Dali has been significantly degraded.
 FROM rust:1.74.0-alpine3.18 as build
 
 WORKDIR /usr/src/dali
-RUN apk add --update --no-cache \
-    --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/main \
-      build-base=0.5-r3 \
-      clang=16.0.6-r1 \
-      clang16-libclang=16.0.6-r1 \
-      expat-dev=2.5.0-r1 \
-      giflib-dev=5.2.1-r4 \
-      glib-dev=2.76.4-r0 \
-      lcms2-dev=2.15-r2 \
-      libexif-dev=0.6.24-r1 \
-      libheif-dev=1.16.2-r0 \
-      libimagequant-dev=4.2.0-r0 \
-      libjpeg-turbo-dev=2.1.5.1-r3 \
-      libpng-dev=1.6.39-r3 \
-      librsvg-dev=2.56.3-r0 \
-      libwebp-dev=1.3.2-r0 \
-      openssl-dev=3.1.4-r1 \
-      orc-dev=0.4.34-r0 \
-      pkgconf=1.9.5-r0 \
-      tiff-dev=4.5.1-r0
+RUN apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/main \
+    build-base=0.5-r3 \
+    clang=16.0.6-r1 \
+    clang16-libclang=16.0.6-r1 \
+    expat-dev=2.5.0-r1 \
+    giflib-dev=5.2.1-r4 \
+    glib-dev=2.76.4-r0 \
+    lcms2-dev=2.15-r2 \
+    libexif-dev=0.6.24-r1 \
+    libheif-dev=1.16.2-r0 \
+    libimagequant-dev=4.2.0-r0 \
+    libjpeg-turbo-dev=2.1.5.1-r3 \
+    libpng-dev=1.6.39-r3 \
+    librsvg-dev=2.56.3-r0 \
+    libwebp-dev=1.3.2-r0 \
+    openssl-dev=3.1.4-r1 \
+    orc-dev=0.4.34-r0 \
+    pkgconf=1.9.5-r0 \
+    tiff-dev=4.5.1-r0
 
 RUN wget https://github.com/libvips/libvips/releases/download/v8.13.3/vips-8.13.3.tar.gz && \
     mkdir /vips && \
@@ -39,8 +40,7 @@ RUN RUSTFLAGS="-C target-feature=-crt-static $(pkg-config vips --libs)" cargo bu
 
 FROM alpine:3.18.4
 
-RUN apk add --update --no-cache \
-    --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/main --virtual build-deps \
+RUN apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/main --virtual build-deps \
       build-base=0.5-r3 \
       clang=16.0.6-r1 \
       clang16-libclang=16.0.6-r1 \
@@ -69,12 +69,25 @@ RUN apk add --update --no-cache \
     rm -rf /vips /vips-8.13.3.tar.gz && \
     apk del build-deps
 
-RUN apk add --update --no-cache libgsf=1.14.50-r1 glib=2.76.4-r0 expat=2.5.0-r1 tiff=4.5.1-r0 libjpeg-turbo=2.1.5.1-r3 \
-     libexif=0.6.24-r1 giflib=5.2.1-r4 librsvg=2.56.3-r0 lcms2=2.15-r2 libpng=1.6.39-r3 orc=0.4.34-r0 libwebp=1.3.2-r0 && \
-  apk add --update --no-cache libimagequant --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main && \
-  apk add --update --no-cache libimagequant --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community libheif=1.16.2-r0 && \
-  apk add --update --no-cache libimagequant --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main libde265=1.0.12-r0 && \
-  export GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0
+RUN apk add --update --no-cache  \
+    --repository=https://dl-cdn.alpinelinux.org/alpine/v3.18/main  \
+    --repository=https://dl-cdn.alpinelinux.org/alpine/v3.18/community \
+      libgsf=1.14.50-r1 \
+      glib=2.76.4-r0 \
+      expat=2.5.0-r1 \
+      tiff=4.5.1-r0 \
+      libjpeg-turbo=2.1.5.1-r3 \
+      libexif=0.6.24-r1 \
+      giflib=5.2.1-r4 \
+      librsvg=2.56.3-r0 \
+      lcms2=2.15-r2 \
+      libpng=1.6.39-r3 \
+      orc=0.4.34-r0 \
+      libwebp=1.3.2-r0 \
+      libimagequant=4.2.0-r0 \
+      libheif=1.16.2-r0 \
+      libde265=1.0.12-r0 && \
+    export GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0
 
 COPY --from=build /usr/src/dali/target/release/dali /usr/local/bin/dali
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN apk add --update --no-cache  \
       libwebp=1.3.2-r0 \
       libimagequant=4.2.0-r0 \
       libheif=1.16.2-r0 \
-      libde265=1.0.12-r0 \
+      libde265=1.0.12-r0
 
 ENV GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,9 @@ RUN apk add --update --no-cache  \
       libwebp=1.3.2-r0 \
       libimagequant=4.2.0-r0 \
       libheif=1.16.2-r0 \
-      libde265=1.0.12-r0 && \
-    export GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0
+      libde265=1.0.12-r0 \
+
+ENV GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0
 
 COPY --from=build /usr/src/dali/target/release/dali /usr/local/bin/dali
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,37 @@
 # (c) Copyright 2019-2023 OLX
-FROM rust:1.73.0-alpine3.17 as build
+FROM rust:1.74.0-alpine3.18 as build
 
 WORKDIR /usr/src/dali
 RUN apk add --update --no-cache \
-    --repository https://dl-cdn.alpinelinux.org/alpine/v3.17/community \
-    --repository https://dl-cdn.alpinelinux.org/alpine/v3.17/main \
-    musl-dev=1.2.3-r5 \
-    vips-dev=8.13.3-r1
+    --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/main \
+      build-base=0.5-r3 \
+      clang=16.0.6-r1 \
+      clang16-libclang=16.0.6-r1 \
+      expat-dev=2.5.0-r1 \
+      giflib-dev=5.2.1-r4 \
+      glib-dev=2.76.4-r0 \
+      lcms2-dev=2.15-r2 \
+      libexif-dev=0.6.24-r1 \
+      libheif-dev=1.16.2-r0 \
+      libimagequant-dev=4.2.0-r0 \
+      libjpeg-turbo-dev=2.1.5.1-r3 \
+      libpng-dev=1.6.39-r3 \
+      librsvg-dev=2.56.3-r0 \
+      libwebp-dev=1.3.2-r0 \
+      openssl-dev=3.1.4-r1 \
+      orc-dev=0.4.34-r0 \
+      pkgconf=1.9.5-r0 \
+      tiff-dev=4.5.1-r0
+
+RUN wget https://github.com/libvips/libvips/releases/download/v8.13.3/vips-8.13.3.tar.gz && \
+    mkdir /vips && \
+    tar xvzf vips-8.13.3.tar.gz -C /vips --strip-components 1 && \
+    cd /vips && \
+    ./configure --enable-debug=no && \
+    make && \
+    make install && \
+    ldconfig /etc/ld.so.conf.d && \
+    rm -rf vips vips-8.13.3.tar.gz
 
 COPY . .
 
@@ -15,11 +40,41 @@ RUN RUSTFLAGS="-C target-feature=-crt-static $(pkg-config vips --libs)" cargo bu
 FROM alpine:3.18.4
 
 RUN apk add --update --no-cache \
-    --repository https://dl-cdn.alpinelinux.org/alpine/v3.17/community \
-    --repository https://dl-cdn.alpinelinux.org/alpine/v3.17/main \
-    vips=8.13.3-r1 \
-    vips-heif=8.13.3-r1 \
-    openssl
+    --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/main --virtual build-deps \
+      build-base=0.5-r3 \
+      clang=16.0.6-r1 \
+      clang16-libclang=16.0.6-r1 \
+      expat-dev=2.5.0-r1 \
+      giflib-dev=5.2.1-r4 \
+      glib-dev=2.76.4-r0 \
+      lcms2-dev=2.15-r2 \
+      libexif-dev=0.6.24-r1 \
+      libheif-dev=1.16.2-r0 \
+      libimagequant-dev=4.2.0-r0 \
+      libjpeg-turbo-dev=2.1.5.1-r3 \
+      libpng-dev=1.6.39-r3 \
+      librsvg-dev=2.56.3-r0 \
+      libwebp-dev=1.3.2-r0 \
+      openssl-dev=3.1.4-r1 \
+      orc-dev=0.4.34-r0 \
+      pkgconf=1.9.5-r0 \
+      tiff-dev=4.5.1-r0 && \
+    wget https://github.com/libvips/libvips/releases/download/v8.13.3/vips-8.13.3.tar.gz && \
+    mkdir /vips &&\
+    tar xvzf vips-8.13.3.tar.gz -C /vips --strip-components 1 && \
+    cd /vips && \
+    ./configure --enable-debug=no --without-OpenEXR --disable-static --enable-silent-rule && \
+    make install-strip  && \
+    ldconfig /etc/ld.so.conf.d && \
+    rm -rf /vips /vips-8.13.3.tar.gz && \
+    apk del build-deps
+
+RUN apk add --update --no-cache libgsf=1.14.50-r1 glib=2.76.4-r0 expat=2.5.0-r1 tiff=4.5.1-r0 libjpeg-turbo=2.1.5.1-r3 \
+     libexif=0.6.24-r1 giflib=5.2.1-r4 librsvg=2.56.3-r0 lcms2=2.15-r2 libpng=1.6.39-r3 orc=0.4.34-r0 libwebp=1.3.2-r0 && \
+  apk add --update --no-cache libimagequant --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main && \
+  apk add --update --no-cache libimagequant --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community libheif=1.16.2-r0 && \
+  apk add --update --no-cache libimagequant --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main libde265=1.0.12-r0 && \
+  export GI_TYPELIB_PATH=/usr/local/lib/girepository-1.0
 
 COPY --from=build /usr/src/dali/target/release/dali /usr/local/bin/dali
 

--- a/src/commons/actix_utils.rs
+++ b/src/commons/actix_utils.rs
@@ -2,24 +2,23 @@
 
 use crate::commons::ProcessImageRequest;
 use actix_web::dev;
-use actix_web::web::Data;
 use actix_web::{Error, FromRequest, HttpRequest};
 use futures::future::{err, ready, Ready};
-use serde_qs::Config;
 
 impl FromRequest for ProcessImageRequest {
     type Error = Error;
     type Future = Ready<Result<Self, Self::Error>>;
+    type Config = ();
 
     fn from_request(req: &HttpRequest, _: &mut dev::Payload) -> Self::Future {
-        match req.app_data::<Data<Config>>() {
+        match req.app_data::<actix_web::web::Data<serde_qs::Config>>() {
             Some(qs_config) => ready(
                 qs_config
                     .deserialize_str::<ProcessImageRequest>(req.query_string())
                     .map_err(actix_web::error::ErrorBadRequest),
             ),
             None => err(actix_web::error::ErrorInternalServerError(
-                "Config not defined to spin new ProcessImageRequest",
+                "Config not defined",
             )),
         }
     }

--- a/src/image_processor/mod.rs
+++ b/src/image_processor/mod.rs
@@ -141,7 +141,7 @@ pub fn process_image(
             let options = ops::PngsaveBufferOptions {
                 q: quality,
                 strip: true,
-                bitdepth: i32::from(8),
+                bitdepth: 8,
                 ..ops::PngsaveBufferOptions::default()
             };
             ops::pngsave_buffer_with_opts(&final_image, &options)

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,5 +1,4 @@
 // (c) Copyright 2019-2023 OLX
-use utils::make_request;
 
 #[macro_use]
 extern crate lazy_static;
@@ -7,14 +6,14 @@ mod utils;
 
 #[test]
 fn test_get_simple() {
-    let result = make_request(utils::RequestParametersBuilder::new("img-test"))
+    let result = utils::make_request(utils::RequestParametersBuilder::new("img-test"))
         .expect("Unable to download file");
     utils::assert_result(&result[..], "raw.jpg");
 }
 
 #[test]
 fn test_get_rotated() {
-    let result = make_request(
+    let result = utils::make_request(
         utils::RequestParametersBuilder::new("img-test").with_rotation(utils::Rotation::R270),
     )
     .expect("Unable to download file");
@@ -24,14 +23,14 @@ fn test_get_rotated() {
 #[test]
 fn test_get_resized() {
     let result =
-        make_request(utils::RequestParametersBuilder::new("img-test").with_size(100, 100))
+        utils::make_request(utils::RequestParametersBuilder::new("img-test").with_size(100, 100))
             .expect("Unable to download file");
     utils::assert_result(&result[..], "resized.jpg");
 }
 
 #[test]
 fn test_get_watermarked_left() {
-    let result = make_request(
+    let result = utils::make_request(
         utils::RequestParametersBuilder::new("img-test").add_watermark(
             "watermark",
             40,
@@ -47,7 +46,7 @@ fn test_get_watermarked_left() {
 
 #[test]
 fn test_get_watermarked_right() {
-    let result = make_request(
+    let result = utils::make_request(
         utils::RequestParametersBuilder::new("img-test").add_watermark(
             "watermark",
             40,
@@ -63,7 +62,7 @@ fn test_get_watermarked_right() {
 
 #[test]
 fn test_get_watermarked_center() {
-    let result = make_request(
+    let result = utils::make_request(
         utils::RequestParametersBuilder::new("img-test").add_watermark(
             "watermark",
             40,
@@ -79,7 +78,7 @@ fn test_get_watermarked_center() {
 
 #[test]
 fn test_get_watermarked_rotated() {
-    let result = make_request(
+    let result = utils::make_request(
         utils::RequestParametersBuilder::new("img-test")
             .add_watermark(
                 "watermark",
@@ -97,7 +96,7 @@ fn test_get_watermarked_rotated() {
 
 #[test]
 fn test_get_encoded_webp() {
-    let result = make_request(
+    let result = utils::make_request(
         utils::RequestParametersBuilder::new("img-test").with_format(utils::ImageFormat::Webp),
     )
     .expect("Unable to download file");
@@ -106,7 +105,7 @@ fn test_get_encoded_webp() {
 
 #[test]
 fn test_get_encoded_heic() {
-    let result = make_request(
+    let result = utils::make_request(
         utils::RequestParametersBuilder::new("img-test").with_format(utils::ImageFormat::Heic),
     )
     .expect("Unable to download file");
@@ -115,7 +114,7 @@ fn test_get_encoded_heic() {
 
 #[test]
 fn test_get_encoded_webp_bad_quality() {
-    let result = make_request(
+    let result = utils::make_request(
         utils::RequestParametersBuilder::new("img-test")
             .with_format(utils::ImageFormat::Webp)
             .with_quality(10),
@@ -126,7 +125,7 @@ fn test_get_encoded_webp_bad_quality() {
 
 #[test]
 fn test_get_raw_bad_quality() {
-    let result = make_request(
+    let result = utils::make_request(
         utils::RequestParametersBuilder::new("img-test")
             .with_format(utils::ImageFormat::Jpeg)
             .with_quality(10),
@@ -137,7 +136,7 @@ fn test_get_raw_bad_quality() {
 
 #[test]
 fn test_get_multiple_watermarks() {
-    let result = make_request(
+    let result = utils::make_request(
         utils::RequestParametersBuilder::new("img-test")
             .add_watermark(
                 "watermark",
@@ -170,7 +169,7 @@ fn test_get_multiple_watermarks() {
 
 #[test]
 fn test_get_watermark_no_alpha() {
-    let result = make_request(
+    let result = utils::make_request(
         utils::RequestParametersBuilder::new("img-test")
             .add_watermark(
                 "watermark",
@@ -189,7 +188,7 @@ fn test_get_watermark_no_alpha() {
 
 #[test]
 fn test_get_exif_watermark() {
-    let result = make_request(
+    let result = utils::make_request(
         utils::RequestParametersBuilder::new("exif")
             .add_watermark(
                 "watermark",
@@ -208,7 +207,7 @@ fn test_get_exif_watermark() {
 
 #[test]
 fn test_get_all_features() {
-    let result = make_request(
+    let result = utils::make_request(
         utils::RequestParametersBuilder::new("img-test")
             .with_format(utils::ImageFormat::Webp)
             .with_quality(50)

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,9 +1,9 @@
 // (c) Copyright 2019-2023 OLX
 
+use actix_http::client::SendRequestError;
 use actix_rt::System;
-use awc::Client;
+use actix_web::client::Client;
 use actix_web::web::Bytes;
-use awc::error::SendRequestError;
 use libvips::ops;
 use libvips::VipsApp;
 use libvips::VipsImage;
@@ -120,13 +120,13 @@ pub fn assert_result(img: &[u8], image_address: &str) {
 }
 
 pub fn make_request(params: RequestParametersBuilder) -> Result<Bytes, SendRequestError> {
-    System::new().block_on(async move {
+    System::new("test").block_on(async move {
         let client = Client::default();
 
         let url = get_url(&params);
         println!("URL: {}", url);
 
-        let request = client.get(url).send();
+        let request = client.get(url).header("User-Agent", "Actix-web").send();
         let mut response = request.await?;
         println!("Response: {:?}", response);
         response


### PR DESCRIPTION
## Why do we need this?
In order to keep the good performance of Dali, we must manually install and configure libvips inside the Docker image. Previously we've tried to use the community built bundles (i.e. vips and vips-heif) and the performance significantly degraded. 

## What does this change?
1. Reverts Actix to 2.0.0 as anything > 2.x does not cope well with large traffic. After 2.x the contributors team has changed and the newer memory optimisations don't work well with hundreds of millions requests per minute. Later we will upgrade to other http library.
2. Manually installs and configures libvips in the Docker image to keep the good performance.