### PR TITLE
feat: extend github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+        # These are peer deps of Cargo and should not be automatically bumped
+        - dependency-name: "semver"
+        - dependency-name: "crates-io"
+    open-pull-requests-limit: 4
+    rebase-strategy: "disabled"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: "rust"
+    directory: "/"
+    schedule:
+      # infrequent updates as this is a library: security updates shouldn't need
+      # a major version bump, and minor versions can be controlled by users
+      # Cargo.lock as they will be compatible.
+      interval: "monthly"
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: ".github/workflows"
+    schedule:
+      interval: weekly

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,51 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+# https://github.com/bcoe/conventional-release-labels
+# https://dev.to/github/how-to-automatically-generate-release-notes-for-your-project-2ng8
+# https://www.conventionalcommits.org/en/v1.0.0/
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: '♻️ Enhancement'
+      labels:
+        - refactor
+        - enhancement
+    - title: '🚀 Features'
+      labels:
+        - feature
+        - enhancement
+    - title: '🐛 Bug Fixes'
+      labels:
+        - fix
+        - bug
+    - title: '⚠️ Changes'
+      labels:
+        - changed
+    - title: '⛔️ Deprecated'
+      labels:
+        - deprecated
+    - title: '🗑 Removed'
+      labels:
+        - removed
+    - title: '🔐 Security'
+      labels:
+        - security
+        - dependabot
+    - title: '📄 Documentation'
+      labels:
+        - docs
+        - documentation
+    - title: '🧩 Dependency Updates'
+      labels:
+        - deps
+        - dependencies
+        - renovate
+    - title: '🧰 Maintenance'
+      label: 'chore'
+    - title: '🧺 Miscellaneous'
+      label: misc
+    - title: 'Other Changes'
+      labels:
+        - "*"
+  ignored_types: []

--- a/.github/workflows/conventional-label.yml
+++ b/.github/workflows/conventional-label.yml
@@ -1,0 +1,9 @@
+on:
+  pull_request:
+    types: [ opened, edited ]
+name: conventional-release-labels
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bcoe/conventional-release-labels@v1

--- a/.github/workflows/lint-pr-title-with-feedback.yml
+++ b/.github/workflows/lint-pr-title-with-feedback.yml
@@ -1,0 +1,45 @@
+# (c) Copyright 2019-2023 OLX
+
+# Attribution: https://github.com/amannn/action-semantic-pull-request/blob/v5.3.0/.github/workflows/lint-pr-title-preview-outputErrorMessage.yml
+name: "Lint PR title preview with feedback"
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: write # needed to write comment to PR
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -1,0 +1,56 @@
+# Delete Docker images after PR merge
+#
+
+name: 'Clean Up PR'
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+
+jobs:
+  purge:
+    name: Delete build artifacts and preview images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: chipkent/action-cleanup-package@v1.0.1
+        with:
+          package-name: ${{ github.event.repository.name }}/dali
+          tag: ${{ github.head_ref }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: stefanluptak/delete-old-pr-artifacts@v1
+        with:
+          workflow_filename: pull-requests-tests.yml
+          debug: true
+  cleanup:
+    name: Clean up branch caches
+    runs-on: ubuntu-latest
+    permissions:
+      # `actions:write` permission is required to delete caches
+      #   See also: https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28#delete-a-github-actions-cache-for-a-repository-using-a-cache-id
+      actions: write
+      contents: read
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+          BRANCH=refs/pull/${{ github.event.pull_request.number }}/merge
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published] # or released ??
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/dali
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          flavor: latest=true
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=master,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/pull-requests-tests.yml
+++ b/.github/workflows/pull-requests-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: rust:1.74.0-alpine3.17
+    container: rust:1.74.0-alpine3.18
     services:
       backend:
         image: nginx:latest

--- a/.github/workflows/pull-requests-tests.yml
+++ b/.github/workflows/pull-requests-tests.yml
@@ -20,7 +20,7 @@ env:
   CI: 1
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
-  RUSTFLAGS_EXTRA: "-D warnings -W rust-2021-compatibility"
+  # RUSTFLAGS_EXTRA: "-D warnings -W rust-2021-compatibility"
 
 jobs:
   test:
@@ -69,7 +69,7 @@ jobs:
       - name: Run tests
         run: |
           set +e
-          RUSTFLAGS="$RUSTFLAGS_EXTRA -C target-feature=-crt-static $(pkg-config vips --libs)" HTTP_HOST=backend cargo test -- --quiet
+          RUSTFLAGS="-C target-feature=-crt-static $(pkg-config vips --libs)" HTTP_HOST=backend cargo test -- --quiet
           exitcode="$?"
           echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
           exit "$exitcode"

--- a/.github/workflows/pull-requests-tests.yml
+++ b/.github/workflows/pull-requests-tests.yml
@@ -1,12 +1,27 @@
 name: pull-request-tests
 
 on:
-  pull_request:
-    branches:
-      - master
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/dali
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CI: 1
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+  RUSTFLAGS_EXTRA: "-D warnings -W rust-2021-compatibility"
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -32,7 +47,19 @@ jobs:
           tar
       - name: Check if nginx is available for files hosting
         run:  curl http://backend/exif --output /dev/null
-      - uses: Swatinem/rust-cache@v2
+      # Cache needs the Cargo.lock file for the cache key and must come after the git checkout
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
       - name: Build Dali
         run:  RUSTFLAGS="-C target-feature=-crt-static $(pkg-config vips --libs)" cargo build
       - name: Run Dali
@@ -40,6 +67,63 @@ jobs:
       - name: Check if Dali is running
         run:  sleep 5 &&  nc -z localhost 8080
       - name: Run tests
-        run:  RUSTFLAGS="-C target-feature=-crt-static $(pkg-config vips --libs)" HTTP_HOST=backend cargo test
-      - name: Exit with the test result
-        run:  exit $?
+        run: |
+          set +e
+          RUSTFLAGS="$RUSTFLAGS_EXTRA -C target-feature=-crt-static $(pkg-config vips --libs)" HTTP_HOST=backend cargo test -- --quiet
+          exitcode="$?"
+          echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
+          exit "$exitcode"
+
+  # Only runs if a pull request is created
+  # ignored by renovate branch auto-commit strategy, which does not create PRs
+  # renovate creates merge branches and merges on test success
+  # if the tests fail, a PR is raised
+  # Only run if the tests were successful
+  docker-preview:
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: ${{ !contains(needs.test.outputs.status, 'failure') }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        if: github.event_name == 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        if: github.event_name == 'pull_request'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: ${{ github.head_ref }}
+
+      - name: Build and push
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Add package image comment to PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        # Inform the user that a preview image has been built and published
+        with:
+          header: pr-docker-image
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            You can pull a preview container image of dali with the below command:
+
+            ```console
+            docker pull ${{ steps.meta.outputs.tags }}
+            ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+# (c) Copyright 2019-2023 OLX
+
+name: release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.repository_owner }}
+        with:
+          semantic_version: 19.0.5
+          dry_run: false
+          extra_plugins: |
+            @semantic-release/changelog@v6.0.3
+            @semantic-release/git@10.0.1
+            @semantic-release/github@9.2.0
+            @semantic-release/commit-analyzer@11.1.0
+            @semantic-release/release-notes-generator@12.1.0
+            semantic-release-major-tag@0.3.2
+            @semantic-release-cargo/semantic-release-cargo@2.2.4

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,47 @@
+{
+  "branches": [
+    "main"
+  ],
+  "ci": false,
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
+        "labels": false,
+        "releasedLabels": false,
+        "publish": true
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md",
+          "Cargo.toml"
+        ],
+        "message": "chore: Release ${nextRelease.version} [skip ci]"
+      }
+    ],
+    [
+      "@semantic-release-cargo/semantic-release-cargo",
+      {
+        "verifyConditions": false,
+        "prepare": true,
+        "publish": false
+      }
+    ]
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN apk add --update --no-cache  \
       libpng=1.6.39-r3 \
       librsvg=2.56.3-r0 \
       libwebp=1.3.2-r0 \
-      openssl=3.1.4-r2 \
+      openssl=3.1.4-r1 \
       orc=0.4.34-r0 \
       tiff=4.5.1-r0
 

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
     "labels": [
       "security"
     ],
-    "automerge": true
+    "automerge": false
   },
   "dependencyDashboard": true,
   "configMigration": true,
@@ -43,7 +43,7 @@
         "patch",
         "digest"
       ],
-      "automerge": true,
+      "automerge": false,
       "automergeType": "branch"
     },
     {


### PR DESCRIPTION
Add and configure the github actions for releases.

* change renovatebot to create pull requests
* add automated cargo version bump and docker image tagging when releasing
* add rust cache and branch cache cleanup
* add conventional commit title helper 
* add conventional labels to new pull requests based on conventional commit syntax
