### PR TITLE
fix: github action errors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,13 +17,6 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-  - package-ecosystem: "rust"
-    directory: "/"
-    schedule:
-      # infrequent updates as this is a library: security updates shouldn't need
-      # a major version bump, and minor versions can be controlled by users
-      # Cargo.lock as they will be compatible.
-      interval: "monthly"
   - package-ecosystem: docker
     directory: "/"
     schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_USER: ${{ github.repository_owner }}
         with:
-          semantic_version: 19.0.5
+          semantic_version: 22.0.8
           dry_run: false
           extra_plugins: |
             @semantic-release/changelog@v6.0.3


### PR DESCRIPTION
#63  introduced some new functionality that could only be tested when a PR was merged.

This is to address some of the errors that were found.