### PR TITLE
Revert "chore: Release 1.6.0 [skip ci]"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "dali"
-version = "1.6.0"
+version = "1.5.0"
 dependencies = [
  "actix-http",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # (c) Copyright 2019-2023 OLX
 [package]
 name = "dali"
-version = "1.6.0"
+version = "1.5.0"
 authors = ["Augusto César Dias <augusto.dias@olx.com>"]
 edition = "2021"
 


### PR DESCRIPTION
The automation failed to create docker images.

We are removing the following tags in order for the changelog to be created and the docker images 🤞 .

* v1
* v1.6
* v1.6.0

The tags will  be removed by.....

```console
git push origin --delete refs/tags/v1 refs/tags/v1.6 refs/tags/v1.6.0
```

Additionally, the 1.6.0 release from the releases page will also be removed.

This MR will then be merged, which will cause the 1.6.0 version to be recreated.

