### PR TITLE
feat(response-headers): forward response headers returned by the storage engine of the images

### DIFF
--- a/.github/workflows/pull-requests-tests.yml
+++ b/.github/workflows/pull-requests-tests.yml
@@ -47,8 +47,8 @@ jobs:
           build-base=0.5-r3
           clang=16.0.6-r1
           clang16-libclang=16.0.6-r1
-          expat-dev=2.6.0-r0
-          giflib-dev=5.2.1-r4
+          expat-dev=2.6.3-r0
+          giflib-dev=5.2.2-r0
           glib-dev=2.76.6-r0
           lcms2-dev=2.15-r2
           libexif-dev=0.6.24-r1
@@ -58,8 +58,8 @@ jobs:
           libpng-dev=1.6.39-r3
           librsvg-dev=2.56.3-r0
           libwebp-dev=1.3.2-r0
-          openssl-dev=3.1.4-r5
-          orc-dev=0.4.34-r0
+          openssl-dev=3.1.7-r0
+          orc-dev=0.4.39-r0
           pkgconf=1.9.5-r0
           tiff-dev=4.5.1-r0
           tar
@@ -93,8 +93,8 @@ jobs:
         run: RUSTFLAGS="-C target-feature=-crt-static $(pkg-config vips --libs)" cargo build
       - name: Run Dali
         run: ./target/debug/dali >> /dev/null &
-      - name: Check if Dali is running
-        run: sleep 5 &&  nc -z localhost 8080
+      - name: Wait for Dali to start
+        run: sleep 5
       - name: Run tests
         run: |
           set +e

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpi
     build-base=0.5-r3 \
     clang=16.0.6-r1 \
     clang16-libclang=16.0.6-r1 \
-    expat-dev=2.6.0-r0 \
-    giflib-dev=5.2.1-r4 \
+    expat-dev=2.6.3-r0 \
+    giflib-dev=5.2.2-r0 \
     glib-dev=2.76.6-r0 \
     lcms2-dev=2.15-r2 \
     libexif-dev=0.6.24-r1 \
@@ -19,8 +19,8 @@ RUN apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpi
     libpng-dev=1.6.39-r3 \
     librsvg-dev=2.56.3-r0 \
     libwebp-dev=1.3.2-r0 \
-    openssl-dev=3.1.4-r5 \
-    orc-dev=0.4.34-r0 \
+    openssl-dev=3.1.7-r0 \
+    orc-dev=0.4.39-r0 \
     pkgconf=1.9.5-r0 \
     tiff-dev=4.5.1-r0
 
@@ -51,8 +51,8 @@ COPY --from=build /usr/local/lib /usr/local/lib
 RUN apk add --update --no-cache  \
     --repository=https://dl-cdn.alpinelinux.org/alpine/v3.18/main  \
     --repository=https://dl-cdn.alpinelinux.org/alpine/v3.18/community \
-      expat=2.6.0-r0 \
-      giflib=5.2.1-r4 \
+      expat=2.6.3-r0 \
+      giflib=5.2.2-r0 \
       glib=2.76.6-r0 \
       lcms2=2.15-r2 \
       libde265=1.0.15-r0 \
@@ -64,8 +64,8 @@ RUN apk add --update --no-cache  \
       libpng=1.6.39-r3 \
       librsvg=2.56.3-r0 \
       libwebp=1.3.2-r0 \
-      openssl=3.1.4-r5 \
-      orc=0.4.34-r0 \
+      openssl=3.1.7-r0 \
+      orc=0.4.39-r0 \
       tiff=4.5.1-r0
 
 COPY --from=build /usr/src/dali/target/release/dali /usr/local/bin/dali

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ The application will compute the number of threads by the following formula: `po
 * Libvips
 * A HTTP server for images
 * Docker
-* Rust
+* Rust (1.74.0)
 
 This application relies on C libvips library. That means it has to be previously installed into the system before compiling and/or running.
 
 For installation follow this [instructions](https://libvips.github.io/libvips/install.html). (Required minimum version 8.10.1)
 
-Using `rustup` is the recommended way to install `rust`. It is a tool that manages and updates rust versions (like `nvm` for node for example). To install it, simply run `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`. Then run `rustup update`.
+Using `rustup` is the recommended way to install `rust`. It is a tool that manages and updates rust versions (like `nvm` for node for example). To install it, simply run `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`. Then run `rustup install 1.74.0`.
 
 To build and run the application, run the following command:
 

--- a/src/image_provider/mod.rs
+++ b/src/image_provider/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 
 #[cfg(feature = "reqwest")]
@@ -13,9 +15,14 @@ pub mod s3;
 #[cfg(not(any(feature = "reqwest", feature = "s3")))]
 compile_error!("only 's3' is available as an extra feature for the image storage service");
 
+pub struct ImageResponse {
+    pub bytes: Vec<u8>,
+    pub response_headers: HashMap<String, Vec<u8>>,
+}
+
 #[async_trait]
 pub trait ImageProvider: Send + Sync {
-    async fn get_file(&self, resource: &str) -> Result<Vec<u8>, ImageProcessingError>;
+    async fn get_file(&self, resource: &str) -> Result<ImageResponse, ImageProcessingError>;
 }
 
 #[allow(unreachable_code)]


### PR DESCRIPTION
## Why do we need this
Dali hasn't been forwarding the response headers from the storage engines from where it has been told to download the images in order to process them (via the `image_address` request parameter). This isn't ideal as the service calling Dali might need to use some metadata. For example, S3 returns the user custom metadata of an object using the response headers (e.g. `x-amz-meta-key : value`. This metadata might be used alongside the processed image for business log within Dali's caller.

## What does this change
1. Forwards the response headers received from the storage engine, when Dali uses the HTTP client (`request`) to download images.
2. Forwards the custom user metadata when Dali uses the S3 client directly to download the images.