### PR TITLE
Docker Build Failing - Fixing with Updating OpenSSL version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpi
     libpng-dev=1.6.44-r0 \
     librsvg-dev=2.58.5-r0 \
     libwebp-dev=1.3.2-r0 \
-    openssl-dev=3.3.3-r0 \
+    openssl-dev=3.3.4-r0 \
     orc-dev=0.4.40-r0 \
     pkgconf=2.2.0-r0 \
     tiff-dev=4.6.0t-r0 \
@@ -68,7 +68,7 @@ RUN apk add --update --no-cache  \
       libwebp=1.3.2-r0 \
       libwebpdemux=1.3.2-r0 \
       libwebpmux=1.3.2-r0 \
-      openssl=3.3.3-r0 \
+      openssl=3.3.4-r0 \
       orc=0.4.40-r0 \
       tiff=4.6.0t-r0
 


### PR DESCRIPTION
While building DALI docker image it is failing because of defined OpenSSL Version.

Reason -

```
We are pinning openssl-dev=3.3.3-r0 explicitly, but the Alpine v3.20 repo currently only has 3.3.4-r0.
```

Logs -

```
DALI 

[+] Building 28.7s (9/15)                                                            docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                 0.0s
 => => transferring dockerfile: 2.88kB                                                               0.0s
 => [internal] load metadata for docker.io/library/rust:1.81.0-alpine3.20                            5.0s
 => [internal] load metadata for docker.io/library/alpine:3.20.0                                     4.8s
 => [internal] load .dockerignore                                                                    0.0s
 => => transferring context: 71B                                                                     0.0s
 => [build 1/6] FROM docker.io/library/rust:1.81.0-alpine3.20@sha256:d6e876ca5fe200f4ac60312b95606  22.3s
 => => resolve docker.io/library/rust:1.81.0-alpine3.20@sha256:d6e876ca5fe200f4ac60312b95606f0b0426  0.0s
 => => sha256:cf04c63912e16506c4413937c7f4579018e4bb25c272d989789cfba77b12f951 4.09MB / 4.09MB       2.3s
 => => sha256:f33d0ba6d79ddcc7adb2e073c295844423f77032e7b03bc7973c24f60d3d5ae3 234.42MB / 234.42MB  20.0s
 => => sha256:47dae75a7979f5c823e78faad77f0683f4120db209a14f80f65d35ffcfb6465c 52.95MB / 52.95MB    12.6s
 => => extracting sha256:cf04c63912e16506c4413937c7f4579018e4bb25c272d989789cfba77b12f951            0.1s
 => => extracting sha256:47dae75a7979f5c823e78faad77f0683f4120db209a14f80f65d35ffcfb6465c            0.5s
 => => extracting sha256:f33d0ba6d79ddcc7adb2e073c295844423f77032e7b03bc7973c24f60d3d5ae3            2.2s
 => [stage-1 1/4] FROM docker.io/library/alpine:3.20.0@sha256:77726ef6b57ddf65bb551896826ec38bc3e53  1.1s
 => => resolve docker.io/library/alpine:3.20.0@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde3  0.0s
 => => sha256:94747bd812346354fd5042870b6e44e5406880a4e6b5736a9cf9c753110df11b 4.09MB / 4.09MB       1.0s
 => => extracting sha256:94747bd812346354fd5042870b6e44e5406880a4e6b5736a9cf9c753110df11b            0.1s
 => [internal] load build context                                                                    0.0s
 => => transferring context: 2.83MB                                                                  0.0s
 => [build 2/6] WORKDIR /usr/src/dali                                                                0.1s
 => ERROR [build 3/6] RUN apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/a  1.3s
------
 > [build 3/6] RUN apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/v3.20/main     build-base=0.5-r3     clang17=17.0.6-r1     clang16-libclang=16.0.6-r5     expat-dev=2.7.0-r0     giflib-dev=5.2.2-r0     glib-dev=2.80.5-r0     lcms2-dev=2.16-r0     libexif-dev=0.6.24-r2     libheif-dev=1.17.6-r1     libimagequant-dev=4.2.2-r0     libjpeg-turbo-dev=3.0.3-r0     libpng-dev=1.6.44-r0     librsvg-dev=2.58.5-r0     libwebp-dev=1.3.2-r0     openssl-dev=3.3.3-r0     orc-dev=0.4.40-r0     pkgconf=2.2.0-r0     tiff-dev=4.6.0t-r0     meson=1.4.0-r2     samurai=1.2-r5:
0.110 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/main/aarch64/APKINDEX.tar.gz
0.738 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/community/aarch64/APKINDEX.tar.gz
1.223 ERROR: unable to select packages:
1.224   openssl-dev-3.3.4-r0:
1.224     breaks: world[openssl-dev=3.3.3-r0]
------
Dockerfile:7
--------------------
   6 |     WORKDIR /usr/src/dali
   7 | >>> RUN apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/v3.20/main \
   8 | >>>     build-base=0.5-r3 \
   9 | >>>     clang17=17.0.6-r1 \
  10 | >>>     clang16-libclang=16.0.6-r5 \
  11 | >>>     expat-dev=2.7.0-r0 \
  12 | >>>     giflib-dev=5.2.2-r0 \
  13 | >>>     glib-dev=2.80.5-r0 \
  14 | >>>     lcms2-dev=2.16-r0 \
  15 | >>>     libexif-dev=0.6.24-r2 \
  16 | >>>     libheif-dev=1.17.6-r1 \
  17 | >>>     libimagequant-dev=4.2.2-r0 \
  18 | >>>     libjpeg-turbo-dev=3.0.3-r0 \
  19 | >>>     libpng-dev=1.6.44-r0 \
  20 | >>>     librsvg-dev=2.58.5-r0 \
  21 | >>>     libwebp-dev=1.3.2-r0 \
  22 | >>>     openssl-dev=3.3.3-r0 \
  23 | >>>     orc-dev=0.4.40-r0 \
  24 | >>>     pkgconf=2.2.0-r0 \
  25 | >>>     tiff-dev=4.6.0t-r0 \
  26 | >>>     meson=1.4.0-r2 \
  27 | >>>     samurai=1.2-r5
  28 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/v3.20/main     build-base=0.5-r3     clang17=17.0.6-r1     clang16-libclang=16.0.6-r5     expat-dev=2.7.0-r0     giflib-dev=5.2.2-r0     glib-dev=2.80.5-r0     lcms2-dev=2.16-r0     libexif-dev=0.6.24-r2     libheif-dev=1.17.6-r1     libimagequant-dev=4.2.2-r0     libjpeg-turbo-dev=3.0.3-r0     libpng-dev=1.6.44-r0     librsvg-dev=2.58.5-r0     libwebp-dev=1.3.2-r0     openssl-dev=3.3.3-r0     orc-dev=0.4.40-r0     pkgconf=2.2.0-r0     tiff-dev=4.6.0t-r0     meson=1.4.0-r2     samurai=1.2-r5" did not complete successfully: exit code: 1
```

Fix -

```
Use openssl-dev=3.3.4-r0
```
