### PR TITLE
fix(optimization): optimize memory allocation

### DIFF
--- a/src/image_processor/mod.rs
+++ b/src/image_processor/mod.rs
@@ -19,9 +19,8 @@ pub fn process_image(
         watermarks,
         rotation,
     } = parameters;
-    let exif_slice = &buffer[..buffer.len().min(65536)];
     let needs_rotation = rotation.is_some()
-        || match rexif::parse_buffer_quiet(exif_slice).0 {
+        || match rexif::parse_buffer_quiet(&buffer[..buffer.len().min(65536)]).0 {
             Ok(data) => data.entries.into_iter().any(|e| {
                 e.tag == rexif::ExifTag::Orientation
                     && e.value.to_i64(0).is_some()

--- a/src/image_processor/mod.rs
+++ b/src/image_processor/mod.rs
@@ -19,8 +19,9 @@ pub fn process_image(
         watermarks,
         rotation,
     } = parameters;
+    let exif_slice = &buffer[..buffer.len().min(65536)];
     let needs_rotation = rotation.is_some()
-        || match rexif::parse_buffer_quiet(&buffer[..]).0 {
+        || match rexif::parse_buffer_quiet(exif_slice).0 {
             Ok(data) => data.entries.into_iter().any(|e| {
                 e.tag == rexif::ExifTag::Orientation
                     && e.value.to_i64(0).is_some()

--- a/src/image_processor/mod.rs
+++ b/src/image_processor/mod.rs
@@ -20,7 +20,7 @@ pub fn process_image(
         rotation,
     } = parameters;
     let needs_rotation = rotation.is_some()
-        || match rexif::parse_buffer_quiet(&buffer[..buffer.len().min(65536)]).0 {
+        || match rexif::parse_buffer_quiet(&buffer[..]).0 {
             Ok(data) => data.entries.into_iter().any(|e| {
                 e.tag == rexif::ExifTag::Orientation
                     && e.value.to_i64(0).is_some()

--- a/src/image_provider/reqwest.rs
+++ b/src/image_provider/reqwest.rs
@@ -84,9 +84,10 @@ pub mod client {
                 })
                 .collect();
             if status.is_success() {
+                let response_length = response.content_length().unwrap_or(0);
                 let mut stream = response.bytes_stream();
                 let mut total_bytes = 0;
-                let mut binary_payload: Vec<u8> = Vec::new();
+                let mut binary_payload: Vec<u8> = Vec::with_capacity(response_length as usize);
                 while let Some(bytes) = stream.try_next().await.map_err(|e| {
                     error!(
                         "failed to read the binary payload of the image '{}'. error: {}",

--- a/src/image_provider/s3.rs
+++ b/src/image_provider/s3.rs
@@ -3,7 +3,7 @@ pub mod s3 {
     use aws_config::default_provider::credentials::DefaultCredentialsChain;
     use aws_sdk_s3::config::Builder;
     use aws_sdk_s3::error::SdkError;
-    use axum::http::StatusCode;
+    use axum::http::{StatusCode, response};
     use log::error;
     use std::collections::HashMap;
     use std::io::Write;
@@ -141,7 +141,8 @@ pub mod s3 {
                     })
                     .collect(),
             };
-            let mut binary_payload: Vec<u8> = Vec::new();
+            let response_length = result.content_length().unwrap_or(0).max(0) as usize;
+            let mut binary_payload: Vec<u8> = Vec::with_capacity(response_length);
             let mut total_bytes = 0;
             while let Some(bytes) = result.body.try_next().await.map_err(|e| {
                 error!(

--- a/src/image_provider/s3.rs
+++ b/src/image_provider/s3.rs
@@ -3,7 +3,7 @@ pub mod s3 {
     use aws_config::default_provider::credentials::DefaultCredentialsChain;
     use aws_sdk_s3::config::Builder;
     use aws_sdk_s3::error::SdkError;
-    use axum::http::{StatusCode, response};
+    use axum::http::{StatusCode};
     use log::error;
     use std::collections::HashMap;
     use std::io::Write;


### PR DESCRIPTION
This PR adds the following:
1. Pre allocate the vectors when downloading the files via either the s3 client or reqwest.
2. Read a smaller chunk of the file during the exif evaluation. 