### PR TITLE
fix(exif): optimize exif evaluation

### DIFF
--- a/src/image_processor/mod.rs
+++ b/src/image_processor/mod.rs
@@ -19,8 +19,9 @@ pub fn process_image(
         watermarks,
         rotation,
     } = parameters;
+    let exif_slice = &buffer[..buffer.len().min(65536)];
     let needs_rotation = rotation.is_some()
-        || match rexif::parse_buffer_quiet(&buffer[..]).0 {
+        || match rexif::parse_buffer_quiet(exif_slice).0 {
             Ok(data) => data.entries.into_iter().any(|e| {
                 e.tag == rexif::ExifTag::Orientation
                     && e.value.to_i64(0).is_some()


### PR DESCRIPTION
The EXIF evaluation is performed for all the files. Because the information needed for the evaluation is stored within the first bytes of the file, it might be more optimal to only read them instead of the whole file.